### PR TITLE
Remove *.py from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,7 +59,6 @@ htmlcov/
 .vscode/
 .ideas/
 _build/
-*.py
 *.sln
 
 #MIR my Files


### PR DESCRIPTION
`*.py` shouldn't be in `.gitignore` - its presence there will silently prevent git from honoring changes to Python files by default